### PR TITLE
Fix display of errors.

### DIFF
--- a/plugin/simpledb.vim
+++ b/plugin/simpledb.vim
@@ -38,7 +38,8 @@ function! simpledb#ExecuteSql(first_line, last_line)
     let cmdline = s:PostgresCommand(conprops, query)
   endif
 
-  silent execute '!(' . cmdline . ' > /tmp/vim-simpledb-result.txt) 2> /tmp/vim-simpledb-result.txt'
+  silent execute '!(' . cmdline . ' > /tmp/vim-simpledb-result.txt) 2> /tmp/vim-simpledb-error.txt'
+  silent execute '!(cat /tmp/vim-simpledb-error.txt >> /tmp/vim-simpledb-result.txt)'
   call s:ShowResults()
   redraw!
 endfunction


### PR DESCRIPTION
In some settings it might occur that the output of stdout and error overlap
which produces output like the following.

```
ERROR:  syntaxTime: 1.118 ms
ar "table_name"
LINE 1: select * table_name;
                 ^
```

After applying this patch vim-simpledb writes the error to a separate file
which gets then appended to the output so that we get a nicer error message
like the following

```
Timing is on.
Time: 1.421 ms
ERROR:  syntax error at or near "table_name"
LINE 1: select * table_name;
                 ^
```
