### PR TITLE
Fixed bug: Multiple calls per line

### DIFF
--- a/ftplugin/sql.vim
+++ b/ftplugin/sql.vim
@@ -1,3 +1,3 @@
-vnoremap <buffer> <enter> :call simpledb#ExecuteSql("'<", "'>")<cr>
-nnoremap <buffer> <enter> :call simpledb#ExecuteSql("1", "$")<cr>
-nnoremap <buffer> <leader><enter> :call simpledb#ExecuteSql("'{", "'}")<cr>
+vnoremap <buffer> <enter> :SimpleDBExecuteSql <cr>
+nnoremap <buffer> <enter> :SimpleDBExecuteSql <cr>
+nnoremap <buffer> <leader><enter> :'{,'}SimpleDBExecuteSql <cr>

--- a/plugin/simpledb.vim
+++ b/plugin/simpledb.vim
@@ -1,3 +1,4 @@
+
 function! s:GetQuery(first, last)
   let query = ''
   let lines = getline(a:first, a:last)
@@ -19,18 +20,18 @@ function! s:ShowResults()
   if bufwinnr(s:result_buf_nr) > 0
     exec bufwinnr(s:result_buf_nr) . "wincmd w"
   else
-    exec 'silent! botright ' . 'sview /tmp/vim-simpledb-result.txt'
+    exec 'silent! botright ' . 'sview +set\ autoread /tmp/vim-simpledb-result.txt '
     let s:result_buf_nr = bufnr('%')
   endif
 
   exec bufwinnr(source_buf_nr) . "wincmd w"
 endfunction
 
-function! simpledb#ExecuteSql(first_line, last_line)
+function! simpledb#ExecuteSql() range
   let conprops = matchstr(getline(1), '--\s*\zs.*')
   let adapter = matchlist(conprops, 'db:\(\w\+\)')
   let conprops = substitute(conprops, "db:\\w\\+", "", "")
-  let query = s:GetQuery(a:first_line, a:last_line)
+  let query = s:GetQuery(a:firstline, a:lastline)
 
   if len(adapter) > 1 && adapter[1] == 'mysql'
     let cmdline = s:MySQLCommand(conprops, query)
@@ -58,3 +59,4 @@ function! s:PostgresCommand(conprops, query)
   return cmdline
 endfunction
 
+command! -range=% SimpleDBExecuteSql <line1>,<line2>call simpledb#ExecuteSql()


### PR DESCRIPTION
Currently, when doing a visual selection and pressing Enter, the function is called once per line due to the interface of vim functions.

I slightly changed it to using function() range instead.

As another small change, I added auto-reload to the result window, so the user doesn't have to accept any reloads of that.
