### PR TITLE
Don't create swap files for temporary results

### DIFF
--- a/plugin/simpledb.vim
+++ b/plugin/simpledb.vim
@@ -21,7 +21,7 @@ function! s:ShowResults()
   if bufwinnr(s:result_buf_nr) > 0
     exec bufwinnr(s:result_buf_nr) . "wincmd w"
   else
-    exec 'silent! botright ' . 'sview +set\ autoread /tmp/vim-simpledb-result.txt '
+    exec 'silent! botright noswapfile sview +set\ autoread /tmp/vim-simpledb-result.txt '
     let s:result_buf_nr = bufnr('%')
   endif
 


### PR DESCRIPTION
I often run into `E325` when I execute the second query after opening a SQL buffer.

This pull requests disables swap files for the temporary file that contains the results of the last query, to avoid `E325`.
