### PR TITLE
Fix end-of-line comments breaking the query

### DIFF
--- a/plugin/simpledb.vim
+++ b/plugin/simpledb.vim
@@ -4,8 +4,9 @@ function! s:GetQuery(first, last)
   let query = ''
   let lines = getline(a:first, a:last)
   for line in lines
-    if line !~ '--.*'
-      let query .= line . "\n"
+    let fragment = matchstr(line, '\(.*\)\(--.*\)\?')
+    if !empty(fragment)
+      let query .= fragment . "\n"
     endif
   endfor
   return query


### PR DESCRIPTION
A query such as
```sql
SELECT *  -- some clarifying comment
FROM people
```
would break, because the previous implementation filters out every line that contains a comment, so that the query sent to the DB would only be
```sql
FROM people
```
This pull requests amends this by extracting the query fragment in front of an inline comment.
(Note that this is my first time messing with vimscript outside my vimrc, but I briefly tested it locally and it worked fine.)