### PR TITLE
redirect stderr to stdout

### DIFF
--- a/plugin/simpledb.vim
+++ b/plugin/simpledb.vim
@@ -41,8 +41,7 @@ function! simpledb#ExecuteSql() range
     let cmdline = s:PostgresCommand(conprops, query)
   endif
 
-  silent execute '!(' . substitute(cmdline, "!", "\\\\!", "g") . ' > /tmp/vim-simpledb-result.txt) 2> /tmp/vim-simpledb-error.txt'
-  silent execute '!(cat /tmp/vim-simpledb-error.txt >> /tmp/vim-simpledb-result.txt)'
+  silent execute '!(' . substitute(cmdline, "!", "\\\\!", "g") . ' > /tmp/vim-simpledb-result.txt 2>&1)'
   call s:ShowResults()
   redraw!
 endfunction


### PR DESCRIPTION
Remove 1 unnecessary execute command call by simply redirecting all
error output to the same stdout location