### PR TITLE
new lines giving trouble in most recent Vim version

### DIFF
--- a/plugin/simpledb.vim
+++ b/plugin/simpledb.vim
@@ -41,7 +41,7 @@ function! simpledb#ExecuteSql() range
     let cmdline = s:PostgresCommand(conprops, query)
   endif
 
-  silent execute '!(' . substitute(cmdline, "!", "\\\\!", "g") . ' > /tmp/vim-simpledb-result.txt 2>&1)'
+  silent execute '! (' . cmdline . ' > /tmp/vim-simpledb-result.txt 2>&1)'
   call s:ShowResults()
   redraw!
 endfunction
@@ -49,7 +49,9 @@ endfunction
 function! s:MySQLCommand(conprops, query)
   let sql_text = shellescape(a:query)
   let sql_text = escape(sql_text, '%')
-  let cmdline = 'echo -e ' . sql_text . '| mysql -v -v -v -t ' . a:conprops
+  let sql_text = substitute(sql_text, "!", "\\\\!", "g")
+  let sql_text = substitute(sql_text, "\n", "\\\\\n", "g")
+  let cmdline = 'echo -e ' . sql_text . ' | mysql -v -v -v -t ' . a:conprops
   return cmdline
 endfunction
 
@@ -59,8 +61,9 @@ function! s:PostgresCommand(conprops, query)
   else
     let sql_text = shellescape(a:query)
   end
-
   let sql_text = escape(sql_text, '%')
+  let sql_text = substitute(sql_text, "!", "\\\\!", "g")
+  let sql_text = substitute(sql_text, "\n", "\\\\\n", "g")
   let cmdline = 'echo -e ' . sql_text . '| psql ' . a:conprops
   return cmdline
 endfunction


### PR DESCRIPTION
I noticed in the latest Vim:

```
VIM - Vi IMproved 8.0 (2016 Sep 12, compiled Jun 26 2017 15:56:42)
Included patches: 1-666
```

that the new lines in my sql files were giving the shell execution trouble so I cleaned things up with a few substitutions and also made sure to replicate those substitutions for the postgres part of the plugin.
