### PR TITLE
Fix shellescape behaviour after change in vim.

### DIFF
--- a/plugin/simpledb.vim
+++ b/plugin/simpledb.vim
@@ -41,26 +41,24 @@ function! simpledb#ExecuteSql() range
     let cmdline = s:PostgresCommand(conprops, query)
   endif
 
-  silent execute '!(' . substitute(cmdline, "!", "\\\\!", "g") . ' > /tmp/vim-simpledb-result.txt 2>&1)'
+  silent execute '!(' . cmdline . ' > /tmp/vim-simpledb-result.txt 2>&1)'
   call s:ShowResults()
   redraw!
 endfunction
 
 function! s:MySQLCommand(conprops, query)
-  let sql_text = shellescape(a:query)
-  let sql_text = escape(sql_text, '%')
+  let sql_text = shellescape(a:query, 1)
   let cmdline = 'echo -e ' . sql_text . '| mysql -v -v -v -t ' . a:conprops
   return cmdline
 endfunction
 
 function! s:PostgresCommand(conprops, query)
   if g:simpledb_show_timing == 1
-    let sql_text = shellescape('\\timing on \\\ ' . a:query)
+    let sql_text = shellescape('\\timing on \\\ ' . a:query, 1)
   else
-    let sql_text = shellescape(a:query)
+    let sql_text = shellescape(a:query, 1)
   end
 
-  let sql_text = escape(sql_text, '%')
   let cmdline = 'echo -e ' . sql_text . '| psql ' . a:conprops
   return cmdline
 endfunction


### PR DESCRIPTION
After https://github.com/vim/vim/issues/1590 vim-simpledb was broken for
me throwing the following error:

> bash: -c: line 0: unexpected EOF while looking for matching `''
> bash: -c: line 1: syntax error: unexpected end of file

Using shellescape to escape special characters as well fixed it for me.
I however didn't do extensive testing with different vim versions or shells.

Let me know if you see issues with this implementation I'm happy to improve it
to get it merged.